### PR TITLE
Added default for HIO_TEST_ROOTS variable in test/run_setup

### DIFF
--- a/test/run_setup
+++ b/test/run_setup
@@ -639,4 +639,8 @@ if [[ $batch -eq 0 ]]; then
 
 fi
 
+if [[ "x$HIO_TEST_ROOTS" -eq "x" ]] ; then
+    export HIO_TEST_ROOTS=posix:/tmp/hio_test
+fi
+
 # --- end of run_setup ---


### PR DESCRIPTION
This enables my machine to run "make check" successfully.

Without this change all tests but run01 fail with a cryptic error message due to the empty bash variable not having a representation in the program's `argv`
