### PR TITLE
libhio: only export hio_ symbols from the shared object

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,14 @@ fi
 AM_INIT_AUTOMAKE([serial-tests])
 LT_INIT
 
+AC_ARG_ENABLE([tests], [AC_HELP_STRING([--enable-tests],
+    				       [Enable hio tests @<:@default=yes@:>@])],
+	      [hio_enable_tests=$enable_tests],[hio_enable_tests=$enable_static])
+
+if test $hio_enable_tests = yes && test "x$enable_static" = "xno" ; then
+    AC_ERROR([Must have static libraries enabled to enable unit tests])
+fi
+
 HIO_CHECK_JSON
 HIO_CHECK_DATAWARP
 HIO_CHECK_XPMEM
@@ -111,6 +119,7 @@ AC_DEFINE([_GNU_SOURCE], [1], [Define _GNU_SOURCE feature macro])
 AC_DEFINE_UNQUOTED([HIO_PREFIX], ["$prefix"], [HIO install prefix])
 AM_CONDITIONAL([HAVE_PDFLATEX], [test $HAVE_PDFLATEX = yes])
 AM_CONDITIONAL([HAVE_MPI], [test $hio_use_mpi = 1])
+AM_CONDITIONAL([ENABLE_TESTS], [test $hio_enable_tests = yes])
 
 AC_SUBST([HIO_PKGCONFIG_REQUIRES], [$hio_pkgconfig_requires])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -45,7 +45,7 @@ json_objects = $(top_builddir)/extra/json/build/arraylist.lo $(top_builddir)/ext
 	$(top_builddir)/extra/json/build/printbuf.lo $(top_builddir)/extra/json/build/random_seed.lo
 # include both the archive (for the dynamic library) and the object files (for the static library)
 libhio_la_LDFLAGS += --whole-archive $(top_builddir)/extra/json/build/.libs/libjson-c.la --no-whole-archive \
-	-version-info 1:0:0
+	-version-info 1:0:0 -export-symbols-regex "^hio_.*"
 libhio_la_LIBADD += $(json_objects)
 libhio_la_CPPFLAGS += -I$(top_builddir)/extra/json/json-c-0.12 -I$(top_builddir)/extra/json/build
 $(top_builddir)/extra/json/build/arraylist.lo: json

--- a/src/builtin-datawarp.c
+++ b/src/builtin-datawarp.c
@@ -178,7 +178,7 @@ static int builtin_datawarp_module_dataset_close (hio_dataset_t dataset) {
       stage_mode = DW_STAGE_AT_JOB_END;
     }
 
-    rc = hio_mkpath (context, pfs_path, pfs_mode);
+    rc = hioi_mkpath (context, pfs_path, pfs_mode);
     if (HIO_SUCCESS != rc) {
       free (dataset_path);
       free (pfs_path);

--- a/src/builtin-posix_component.c
+++ b/src/builtin-posix_component.c
@@ -102,7 +102,7 @@ static int builtin_posix_create_dataset_dirs (builtin_posix_module_t *posix_modu
     return hioi_err_errno (errno);
   }
 
-  rc = hio_mkpath (context, path, access_mode);
+  rc = hioi_mkpath (context, path, access_mode);
   if (0 > rc || EEXIST == errno) {
     if (EEXIST != errno) {
       hioi_err_push (hioi_err_errno (errno), &context->c_object, "posix: error creating context directory: %s",
@@ -130,7 +130,7 @@ static int builtin_posix_create_dataset_dirs (builtin_posix_module_t *posix_modu
       return hioi_err_errno (errno);
     }
 
-    rc = hio_mkpath (context, path, access_mode);
+    rc = hioi_mkpath (context, path, access_mode);
     if (0 > rc || EEXIST == errno) {
       if (EEXIST != errno) {
         hioi_err_push (hioi_err_errno (errno), &context->c_object, "posix: error creating context directory: %s",

--- a/src/hio_context.c
+++ b/src/hio_context.c
@@ -89,7 +89,7 @@ static void hioi_context_release (hio_object_t object) {
  * value (to reduce logging overhead) consisting of:
  *   <hostname>:<rank> <context_name>  (:<rank> only if MPI active)
  */
-void hio_context_msg_id(hio_context_t context, int include_rank) {
+static void hioi_context_msg_id(hio_context_t context, int include_rank) {
   char tmp_id[256];
   char * p;
   int rc;
@@ -132,7 +132,7 @@ static hio_context_t hio_context_alloc (const char *identifier) {
   new_context->c_print_stats = false;
   new_context->c_rank = 0;
   new_context->c_size = 1;
-  hio_context_msg_id(new_context, 0); 
+  hioi_context_msg_id(new_context, 0); 
 
 #if HIO_MPI_HAVE(3)
   new_context->c_shared_comm = MPI_COMM_NULL;
@@ -475,7 +475,7 @@ int hio_init_mpi (hio_context_t *new_context, MPI_Comm *comm, const char *config
 
   MPI_Comm_rank (context->c_comm, &context->c_rank);
   MPI_Comm_size (context->c_comm, &context->c_size);
-  hio_context_msg_id(context, 1); 
+  hioi_context_msg_id(context, 1); 
 
   rc = hio_init_common (context, config_file, config_file_prefix, context_name);
   if (HIO_SUCCESS != rc) {

--- a/src/hio_internal.c
+++ b/src/hio_internal.c
@@ -370,7 +370,7 @@ uint64_t hioi_gettime (void) {
   return 1000000 * tv.tv_sec + tv.tv_usec;
 }
 
-int hio_mkpath (hio_context_t context, const char *path, mode_t access_mode) {
+int hioi_mkpath (hio_context_t context, const char *path, mode_t access_mode) {
   char *tmp = strdup (path);
   int rc;
 

--- a/src/hio_request.c
+++ b/src/hio_request.c
@@ -34,8 +34,8 @@ void hioi_request_release (hio_request_t request) {
   }
 }
 
-int hio_request_test_internal (hio_request_t *requests, int nrequests, ssize_t *bytes_transferred, bool *complete,
-                               bool noset_null) {
+static int hioi_request_test_internal (hio_request_t *requests, int nrequests, ssize_t *bytes_transferred,
+                                       bool *complete, bool noset_null) {
   int ncomplete = 0;
 
   for (int i = 0 ; i < nrequests ; ++i) {
@@ -74,7 +74,7 @@ int hio_request_test (hio_request_t *requests, int nrequests, ssize_t *bytes_tra
     return HIO_ERR_BAD_PARAM;
   }
 
-  return hio_request_test_internal (requests, nrequests, bytes_transferred, complete, false);
+  return hioi_request_test_internal (requests, nrequests, bytes_transferred, complete, false);
 }
 
 int hio_request_wait (hio_request_t *requests, int nrequests, ssize_t *bytes_transferred) {
@@ -82,7 +82,7 @@ int hio_request_wait (hio_request_t *requests, int nrequests, ssize_t *bytes_tra
   int rc;
 
   do {
-    rc = hio_request_test_internal (requests, nrequests, bytes_transferred, NULL, !first);
+    rc = hioi_request_test_internal (requests, nrequests, bytes_transferred, NULL, !first);
     if (nrequests == rc) {
       return HIO_SUCCESS;
     }

--- a/src/include/hio_internal.h
+++ b/src/include/hio_internal.h
@@ -167,7 +167,7 @@ uint64_t hioi_gettime (void);
  * errno global variable. See the man page for mkdir(2) for
  * more information.
  */
-int hio_mkpath (hio_context_t context, const char *path, mode_t access_mode);
+int hioi_mkpath (hio_context_t context, const char *path, mode_t access_mode);
 
 /**
  * Share a string with all processes in a context

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -16,6 +16,8 @@ EXTRA_DIST = run_setup run_combo run01 run02 run03 run04 run05 run07 run08 run09
 clean-local:
 	-rm -rf .test_root1
 
+if ENABLE_TESTS
+
 noinst_PROGRAMS = test01.x error_test.x
 if HAVE_MPI
 noinst_PROGRAMS += xexec.x
@@ -33,3 +35,7 @@ xexec_x_SOURCES = xexec.c cw_misc.c cw_misc.h
 # NTH: override configure CFLAGS warnings/pedantic for now
 xexec_x_CFLAGS = -DMPI -DHIO -DDLFCN -w -Wno-pedantic
 xexec_x_LDFLAGS = -ldl -lm
+
+error_test_x_LDADD = ../src/.libs/libhio.a
+
+endif


### PR DESCRIPTION
This commit updates libhio.so to only export the hio_ symbols. To
continue supporting internal unit tests a new option has been
added --enable-tests that requires --enable-static (default). Tests
can not be built with --disable-static at this time.

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov
