### PR TITLE
configure: update Cray wrapper detection to handle setting CC=cc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@ AM_SILENT_RULES([yes])
 
 hio_use_mpi=0
 
-if ( test -n "$XTOS_VERSION" || test -n "$CRAYPE_DIR" ) && test ! "$CC" ; then
+if ( test -n "$XTOS_VERSION" || test -n "$CRAYPE_DIR" ) && (test -z $CC || test "$CC" = cc) ; then
     # Work around Cray idiosyncrasies
     # Don't let the Cray wrapper bring in extra crap
     PE_VERSION=`echo $XTOS_VERSION | sed 's/\..*//g'`


### PR DESCRIPTION
This commit fixes an issue with Cray wrapper detection if the user
specified CC=cc. This is effectively the same as not setting CC on
the system.

Signed-off-by: Nathan Hjelm hjelmn@me.com
