### PR TITLE
core: add and alternate directory structure and rework list and dump

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,18 @@
 HIO NEWS
 ========
 
-Last updated 2017-03-16
+Last updated 2018-01-04
+
+Release hio.1.4.1.0-rc1
+
+This is a new release that adds support for importing files not written by
+libhio. This support can be enabled by setting the posix_simple_filename
+and posix_simple_import. This support is not enabled by default. This
+release additionally adds support for a new directory layout. The new
+layout creates a single directory in the data root instead of creating
+a hierarchical directory structure. This new support can be enabled by
+setting dataset_posix_directory_mode=single. The default directory
+structure has not changed but may change in the 1.5.0 release.
 
 Release hio.1.4.0.0
 

--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([libhio], [1.4.1], [hjelmn@lanl.gov])
+AC_INIT([libhio], [1.4.1.0-rc1], [hjelmn@lanl.gov])
 AC_CONFIG_SRCDIR([src/hio_context.c])
 AC_CONFIG_HEADERS([src/include/hio_config.h])
 AC_CONFIG_MACRO_DIR([m4])

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # -*- mode: shell-script-mode -*-
 #
-# Copyright (c) 2014-2017 Los Alamos National Security, LLC. All rights
+# Copyright (c) 2014-2018 Los Alamos National Security, LLC. All rights
 #                         reserved.
 # $COPYRIGHT$
 #
@@ -10,7 +10,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([libhio], [1.4.1.0-rc1], [hjelmn@lanl.gov])
+AC_INIT([libhio], [1.4.1.0-rc2], [hjelmn@lanl.gov])
 AC_CONFIG_SRCDIR([src/hio_context.c])
 AC_CONFIG_HEADERS([src/include/hio_config.h])
 AC_CONFIG_MACRO_DIR([m4])

--- a/src/api/dataset_open.c
+++ b/src/api/dataset_open.c
@@ -18,7 +18,7 @@ static int hioi_dataset_open_last (hio_dataset_t dataset) {
   hio_dataset_list_t *list;
   int64_t id = dataset->ds_id;
   hio_module_t *module;
-  int rc;
+  int rc = HIO_ERR_NOT_FOUND;
 
   list = hioi_dataset_list_get (context, hioi_object_identifier (dataset), id);
   if (NULL == list) {

--- a/src/builtin-posix_component.c
+++ b/src/builtin-posix_component.c
@@ -1253,6 +1253,8 @@ static int builtin_posix_module_dataset_close (hio_dataset_t dataset) {
     }
   }
 
+  dataset->ds_stat.s_ctime += hioi_gettime () - start;
+
 #if HIO_MPI_HAVE(3)
   /* release the shared state if it was allocated */
   (void) hioi_dataset_shared_fini (dataset);
@@ -1260,6 +1262,8 @@ static int builtin_posix_module_dataset_close (hio_dataset_t dataset) {
   /* release the dataset map if one was allocated */
   (void) hioi_dataset_map_release (dataset);
 #endif
+
+  (void) hioi_dataset_aggregate_statistics (dataset);
 
   if ((dataset->ds_flags & HIO_FLAG_WRITE) && !posix_dataset->ds_simple_omit_directory) {
     char *path;
@@ -1763,7 +1767,9 @@ static int builtin_posix_element_translate_strided (builtin_posix_module_t *posi
 
   if (file_id != file->f_bid || file->f_element != element) {
     if (file->f_bid >= 0) {
+      uint64_t start = hioi_gettime ();
       POSIX_TRACE_CALL(posix_dataset, hioi_file_close (file), "file_close", file->f_bid, 0);
+      posix_dataset->base.ds_stat.s_ctime += hioi_gettime () - start;
     }
     file->f_bid = -1;
 
@@ -1851,7 +1857,9 @@ static int builtin_posix_element_translate_opt (builtin_posix_module_t *posix_mo
 
   if (file_index != file->f_bid) {
     if (file->f_bid >= 0) {
+      uint64_t start = hioi_gettime ();
       POSIX_TRACE_CALL(posix_dataset, hioi_file_close (file), "file_close", file->f_bid, 0);
+      posix_dataset->base.ds_stat.s_ctime += hioi_gettime () - start;
     }
 
     file->f_bid = -1;

--- a/src/builtin-posix_component.c
+++ b/src/builtin-posix_component.c
@@ -1115,8 +1115,7 @@ static int builtin_posix_module_dataset_open (struct hio_module_t *module, hio_d
   if (dataset->ds_flags & HIO_FLAG_TRUNC) {
     /* blow away the existing dataset */
     if (0 == context->c_rank) {
-      (void) builtin_posix_module_dataset_unlink (module, hioi_object_identifier(dataset),
-                                                  dataset->ds_id);
+      (void) module->dataset_unlink (module, hioi_object_identifier(dataset), dataset->ds_id);
     }
   }
 

--- a/src/builtin-posix_component.c
+++ b/src/builtin-posix_component.c
@@ -561,6 +561,10 @@ static int builtin_posix_module_dataset_list (struct hio_module_t *module, const
   /* set the correct module pointer for this rank */
   for (int i = num_sets[0] ; i < list->header_count ; ++i) {
     list->headers[i].module = module;
+    if (0 != context->c_rank) {
+      /* dataset path pointer is not valid on non-zero ranks. it isn't needed on there ranks at this time. */
+      list->headers[i].ds_path = NULL;
+    }
   }
 
   return HIO_SUCCESS;

--- a/src/builtin-posix_component.h
+++ b/src/builtin-posix_component.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:2 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2017 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2014-2018 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -26,6 +26,13 @@ typedef enum builtin_posix_dataset_fmode {
   /** write block across multiple files */
   HIO_FILE_MODE_STRIDED,
 } builtin_posix_dataset_fmode_t;
+
+typedef enum builtin_posix_dataset_dmode {
+  /** use a hierarchical directory structure (context.hio/dataset/id) */
+  HIO_DIR_MODE_HIERARCHICAL,
+  /** use a single directory structure (context.dataset.id.hiod) */
+  HIO_DIR_MODE_SINGLE,
+} builtin_posix_dataset_dmode_t;
 
 /* data types */
 typedef struct builtin_posix_module_t {
@@ -88,11 +95,14 @@ typedef struct builtin_posix_module_dataset_t {
 
   /** attempt to import POSIX file(s) if no HIO dataset is found */
   bool                ds_simple_import;
+
+  /** directory structure mode */
+  builtin_posix_dataset_dmode_t ds_dmode;
 } builtin_posix_module_dataset_t;
 
 extern hio_component_t builtin_posix_component;
 
 int builtin_posix_module_dataset_list_internal (struct hio_module_t *module, const char *name,
-                                                hio_dataset_header_t **headers, int *count);
+                                                int priority, hio_dataset_list_t *list);
 
 #endif /* BUILTIN_POSIX_COMPONENT_H */

--- a/src/hio_dataset.c
+++ b/src/hio_dataset.c
@@ -527,6 +527,21 @@ static int hioi_dataset_header_compare_highest (const void *a, const void *b) {
   return ((headera->ds_id > headerb->ds_id) - (headera->ds_id < headerb->ds_id));
 }
 
+int hioi_dataset_list_resize (hio_dataset_list_t *list, size_t new_count) {
+  hio_dataset_header_t *tmp;
+
+  tmp = (hio_dataset_header_t *) realloc (list->headers, new_count * sizeof (*tmp));
+  if (NULL == tmp) {
+    return HIO_ERR_OUT_OF_RESOURCE;
+  }
+
+  list->header_count = new_count;
+  list->headers = tmp;
+
+  return HIO_SUCCESS;
+
+}
+
 int hioi_dataset_list_sort (hio_dataset_list_t *list, int64_t id) {
   int (*compar) (const void *, const void *);
 

--- a/src/include/hio.h
+++ b/src/include/hio.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:2 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2017 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2014-2018 Los Alamos National Security, LLC.  All rights
  *                         reserved. 
  * $COPYRIGHT$
  * 
@@ -278,6 +278,12 @@
  *   directly in the data root (not in the directory structure). The file name(s) used are taken
  *   from the posix_simple_filename configuration variable.
  *
+ * - @b dataset_posix_directory_mode - Directory structure to use when creating a new dataset. The
+ *   valid values are hierarchical and single. The hierarchical structure stores new datasets in
+ *   the context.hio/dataset/id directory. The single format stores new datasets in the
+ *   context.dataset.id.hiod directory. The current default is the use the hierarchical structure
+ *   but this may change in a future release.
+ *
  * - @b posix_simple_filename - File names(s) to use when reading/writing POSIX files in simple mode.
  *   The file name can be a single POSIX file or can include any of %c, %d, %i, %e, or %r. These expand
  *   to context name, dataset name, dataset identifier, element name, and rank respectively. Both rank
@@ -450,6 +456,12 @@ typedef struct hio_object *hio_object_t;
  * @brief Most recently modified dataset id
  */
 #define HIO_DATASET_ID_NEWEST (int64_t) -0x10000002
+
+/**
+ * @ingroup API
+ * @brief Any dataset id
+ */
+#define HIO_DATASET_ID_ANY (int64_t) -0x10000004
 
 /**
  * @ingroup API

--- a/src/include/hio_component.h
+++ b/src/include/hio_component.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:2 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2017 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2014-2018 Los Alamos National Security, LLC.  All rights
  *                         reserved. 
  * $COPYRIGHT$
  * 
@@ -20,6 +20,7 @@
 
 struct hio_module_t;
 struct hio_dataset_header_t;
+struct hio_dataset_list_t;
 
 /**
  * Open a dataset with an hio module
@@ -75,10 +76,10 @@ typedef int
  */
 typedef int
 (*hio_module_dataset_list_fn_t) (struct hio_module_t *module, const char *name,
-                                 struct hio_dataset_header_t **headers, int *count);
+                                 int priority, struct hio_dataset_list_t *list);
 
 typedef int
-(*hio_module_dataset_dump_fn_t) (struct hio_module_t *module, const char *name, int64_t id,
+(*hio_module_dataset_dump_fn_t) (struct hio_module_t *module, const struct hio_dataset_header_t *header,
                                  uint32_t dump_flags, int rank, FILE *fh);
 
 /**

--- a/src/include/hio_internal.h
+++ b/src/include/hio_internal.h
@@ -369,6 +369,14 @@ hio_dataset_list_t *hioi_dataset_list_alloc (void);
  */
 void hioi_dataset_list_release (hio_dataset_list_t *list);
 
+/**
+ * Resize a dataset list array
+ *
+ * @param[in] list        list to resize
+ * @param[in] new_count   new size for list array
+ */
+int hioi_dataset_list_resize (hio_dataset_list_t *list, size_t new_count);
+
 
 /**
  * Get a list of datasets from all data roots

--- a/src/include/hio_internal.h
+++ b/src/include/hio_internal.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:2 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2016 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2014-2018 Los Alamos National Security, LLC.  All rights
  *                         reserved. 
  * $COPYRIGHT$
  * 
@@ -352,7 +352,38 @@ hio_dataset_backend_data_t *hioi_dbd_lookup_backend_data (hio_dataset_data_t *da
  *
  * This function is used internally for sorting header arrays.
  */
-int hioi_dataset_headers_sort (hio_dataset_header_t *headers, int count, int64_t id);
+int hioi_dataset_list_sort (hio_dataset_list_t *list, int64_t id);
+
+/**
+ * Allocates an hio dataset list structure
+ */
+hio_dataset_list_t *hioi_dataset_list_alloc (void);
+
+/**
+ * Release an hio dataset list structure
+ *
+ * @param[in] list        list to release
+ *
+ * After this call all the memory associated with a dataset listing will be released. The
+ * memory pointed to by list will no longer be valid.
+ */
+void hioi_dataset_list_release (hio_dataset_list_t *list);
+
+
+/**
+ * Get a list of datasets from all data roots
+ *
+ * @param[in] context      libhio context object
+ * @param[in] dataset_name data set name to list (may be NULL)
+ * @param[in] sort_key     sort key to use (see hio.h)
+ *
+ * @returns hio list object on success
+ * @returns NULL on failure
+ *
+ * This functions lists all the available (and no so available) datasets on the current
+ * context. The returned list must be freed using hioi_dataset_list_release().
+ */
+hio_dataset_list_t *hioi_dataset_list_get (hio_context_t context, const char *dataset_name, int64_t sort_key);
 
 /* element functions */
 

--- a/src/include/hio_internal.h
+++ b/src/include/hio_internal.h
@@ -324,6 +324,18 @@ void hioi_dataset_add_element (hio_dataset_t dataset, hio_element_t element);
  */
 int hioi_dataset_data_lookup (hio_context_t context, const char *name, hio_dataset_data_t **data);
 
+/**
+ * Aggregate performance statistics on all processes
+ *
+ * @param[in] dataset      hio dataset
+ *
+ * This is a collective routine which aggregates all the statistics for the dataset. It
+ * should be called after all IO has completed (including flush and close) but before
+ * the dataset is serialized.
+ */
+int hioi_dataset_aggregate_statistics (hio_dataset_t dataset);
+
+
 /* context dataset persistent data functions */
 
 /**

--- a/src/include/hio_types.h
+++ b/src/include/hio_types.h
@@ -650,6 +650,9 @@ struct hio_dataset {
     /** total number of read operations */
     atomic_ulong        s_rcount;
 
+    /** total time spent closing file(s) */
+    uint64_t            s_ctime;
+
     /** aggregate number of bytes read */
     uint64_t            s_abread;
     /** aggregate read time */
@@ -664,6 +667,9 @@ struct hio_dataset {
     uint64_t            s_awcount;
     /** total number of read operations */
     uint64_t            s_arcount;
+
+    /** total time spent closing file(s) */
+    uint64_t            s_actime;
   } ds_stat;
 
   /** data associated with this dataset */

--- a/src/include/hio_types.h
+++ b/src/include/hio_types.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:2 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2017 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2014-2018 Los Alamos National Security, LLC.  All rights
  *                         reserved. 
  * $COPYRIGHT$
  * 
@@ -824,8 +824,16 @@ struct hio_dataset_header_t {
   int      ds_mode;
   /** dataset status (set at close time) */
   int      ds_status;
+  /** dataset path */
+  char    *ds_path;
 };
 typedef struct hio_dataset_header_t hio_dataset_header_t;
+
+struct hio_dataset_list_t {
+  hio_dataset_header_t *headers;
+  size_t header_count;
+};
+typedef struct hio_dataset_list_t hio_dataset_list_t;
 
 /**
  * Compare two headers

--- a/src/manifest/hio_manifest.c
+++ b/src/manifest/hio_manifest.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:2 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2016 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2014-2018 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -19,6 +19,7 @@
 #include <assert.h>
 #include <unistd.h>
 #include <bzlib.h>
+#include <libgen.h>
 
 #if !defined(__STRICT_ANSI__)
 /* silence pedantic error about extension usage in json-c */
@@ -971,6 +972,14 @@ int hioi_manifest_read (hio_context_t context, const char *path, hio_manifest_t 
 
   rc = hioi_manifest_deserialize (context, buffer, file_size, manifest_out);
   free (buffer);
+
+  if (HIO_SUCCESS == rc) {
+    char *location = strdup (path), *tmp;
+
+    tmp = dirname (location);
+    hioi_manifest_set_string (manifest_out[0]->json_object, HIO_MANIFEST_KEY_LOCATION, tmp);
+    free (location);
+  }
 
   return rc;
 }

--- a/src/manifest/hio_manifest.h
+++ b/src/manifest/hio_manifest.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:2 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2016 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2014-2018 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -25,6 +25,8 @@
 #define HIO_MANIFEST_KEY_RANK        "rank"
 #define HIO_MANIFEST_KEY_CONFIG      "config"
 #define HIO_MANIFEST_KEY_PERF        "perf"
+/* temporary key used by dump */
+#define HIO_MANIFEST_KEY_LOCATION    "location"
 
 #define HIO_MANIFEST_KEY_DATASET_MODE "hio_dataset_mode"
 #define HIO_MANIFEST_KEY_FILE_MODE    "hio_file_mode"

--- a/src/manifest/hio_manifest_dump.c
+++ b/src/manifest/hio_manifest_dump.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:2 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2016 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2014-2018 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -22,6 +22,7 @@ static struct hioi_key_mapping_t hioi_key_mapping[] = {
   {.key = HIO_MANIFEST_KEY_VERSION, .value = "Manifest version"},
   {.key = HIO_MANIFEST_KEY_COMPAT, .value = "Manifest compatibility version"},
   {.key = HIO_MANIFEST_KEY_IDENTIFIER, .value = "Name"},
+  {.key = HIO_MANIFEST_KEY_LOCATION, .value = "Location"},
   {.key = HIO_MANIFEST_KEY_DATASET_ID, .value = "Dataset identifier"},
   {.key = HIO_MANIFEST_KEY_SIZE, .value = "Size"},
   {.key = HIO_MANIFEST_KEY_HIO_VERSION, .value = "libhio version"},

--- a/test/hio_example.c
+++ b/test/hio_example.c
@@ -110,7 +110,6 @@ void checkpoint (void *data, size_t count, size_t stride, int timestep) {
              (void *)((intptr_t) data + sizeof (float)),
               count, sizeof (int), stride);
   IF_PRT_X( bw < 0, "hio_element_write_strided bw: %zd", bw);
-  offset += bw;
 
   /* flush all data locally (not really needed here since the close will flush everything) */
   hrc = hio_element_flush (hio_element, HIO_FLUSH_MODE_LOCAL);

--- a/tools/hio_dump.c
+++ b/tools/hio_dump.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:2 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2016-2017 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2016-2018 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -40,7 +40,7 @@ static void print_version (void) {
 int main (int argc, char *argv[]) {
   const char *data_root, *context = NULL, *dataset = NULL;
   int opt, opt_index, list_rank = -1;
-  int64_t dataset_id = -1;
+  int64_t dataset_id = HIO_DATASET_ID_ANY;
   uint32_t flags = 0;
 
   struct option long_options[] = {


### PR DESCRIPTION
This commit adds an alternate directory for POSIX filesystems. This
alternate structure stores the dataset in a directory with the name
context.dataset.id.hiod. In order to support this alternate format
both dataset list and dump have been reworked.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>