### PR TITLE
travis: force relink of gcc for os-x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
             - m4
 
 before_script:
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]] ; then brew install openmpi ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]] ; then brew install openmpi ;  brew link --overwrite gcc ; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]] ; then sudo apt-get -qq update ; sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1397BC53640DB551 ; sudo apt-get -qq install openmpi-bin libopenmpi-dev ; fi
 
 script:


### PR DESCRIPTION
openmpi tries to pull in gcc-7.3.0, which fails
currently on travis with an error like this:

==> Downloading https://homebrew.bintray.com/bottles/gcc-7.3.0.sierra.bottle.tar.gz
==> Pouring gcc-7.3.0.sierra.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink include/c++
Target /usr/local/include/c++
already exists. You may want to remove it:
  rm '/usr/local/include/c++'

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>