### PR TITLE
hdf5/test: need to call HDF5_hio_init

### DIFF
--- a/hdf5-hio/test/hdf5_hio_test.c
+++ b/hdf5-hio/test/hdf5_hio_test.c
@@ -867,6 +867,7 @@ mpi_rank = 0;
 	goto finish;
 
 
+    H5FD_hio_init();
     H5FD_hio_settings_init(&settings);
     H5FD_hio_set_elem_name(&settings, "elem");
     H5FD_hio_set_setid(&settings, 23888221L);


### PR DESCRIPTION
don't see how this test use to be working.
Need to call HDF5_hio_init to set the driver id correctly.

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>