### PR TITLE
hdf5: make docs optional

### DIFF
--- a/hdf5-hio/Makefile.am
+++ b/hdf5-hio/Makefile.am
@@ -1,6 +1,6 @@
 # -*- Makefile.am -*-
 #
-# Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
+# Copyright (c) 2014-2018 Los Alamos National Security, LLC. All rights
 #                         reserved.
 # $COPYRIGHT$
 #
@@ -11,7 +11,7 @@
 
 ACLOCAL_AMFLAGS=-I m4
 
-SUBDIRS = src test doc
+SUBDIRS = src test
 
 EXTRA_DIST =
 DISTCLEANFILES =


### PR DESCRIPTION
With the current makefile, configuring in hdf5
hio plugin always ends up trying to generate docs.
Make generating hdf5/hio plugin docs optional with

make docs

Signed-off-by: Howard Pritchard <howardp@lanl.gov>