### PR TITLE
fix configuring from dist problem

### DIFF
--- a/hdf5-hio/Makefile.am
+++ b/hdf5-hio/Makefile.am
@@ -11,7 +11,7 @@
 
 ACLOCAL_AMFLAGS=-I m4
 
-SUBDIRS = src test
+SUBDIRS = src test doc
 
 EXTRA_DIST =
 DISTCLEANFILES =

--- a/hdf5-hio/doc/Makefile.am
+++ b/hdf5-hio/doc/Makefile.am
@@ -5,7 +5,7 @@ if HAVE_PDFLATEX
 EXTRA_DIST += libhdf5hio_api.pdf
 endif
 
-all: libhdf5hio_api.pdf
+docs: libhdf5hio_api.pdf
 
 libhdf5hio_api.pdf:latex/refman.pdf
 	cp latex/refman.pdf libhdf5hio_api.pdf


### PR DESCRIPTION
The original attempt to disable building hdf5-hio plugin
docs messed up configures from the release tarballs.

This fixes that problem, while also not always generating
hdf5-hio plugin documentation when just building the plugin.

Fixes #39

Signed-off-by: Howard Pritchard <howardp@lanl.gov>