### PR TITLE
spack: fix for spack to work on non-cray systems

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ if ( test -n "$XTOS_VERSION" || test -n "$CRAYPE_DIR" ) && (test -z $CC || test 
     if test ! -n "$LD" ; then
         LD=ld
     fi
-elif test ${MPICC} = "mpicc" ; then
+elif test -n "$MPICC" ; then
     CC=${MPICC}
     CXX=${MPICXX}
     hio_use_mpi=1


### PR DESCRIPTION
or when one wants to use Open MPI on a cray system with spack.
The problem is that when using an MPI with spack, its going to
use a long value for the CC and CXX variables.  This confused
the libhio configury, resulting in it being built without mpi
support, leading to failure of xexec to properly compile, etc.

This commit fixes that problem.

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>